### PR TITLE
Add unlimited strength encryption policy to allow de-crypting encrypt…

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-oraclejdk8:slim
+FROM anapsix/alpine-java:8_jdk_unlimited
 
 VOLUME /tmp
 ADD docker-startup.sh /


### PR DESCRIPTION
…ed configuration property values

While testing in the remote environment, I found that we were using a JDK that didn't have the unshackled JCE as our base image.  This updates our base docker image to a JDK that contains the unlimited JCE policy.