### PR TITLE
Use cloud bus amqp instead of cloud stream rabbit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
     <unit-tests.skip>false</unit-tests.skip>
     <integration-tests.skip>true</integration-tests.skip>
     <docker.image.prefix>fwsbac</docker.image.prefix>
-    <spring.cloud.config.version>1.2.3.RELEASE</spring.cloud.config.version>
 
     <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
@@ -31,8 +30,8 @@
     <dependencies>
       <dependency>
         <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-config-server</artifactId>
-        <version>${spring.cloud.config.version}</version>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <version>Camden.SR6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -50,10 +49,8 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
-      <version>1.1.3.RELEASE</version>
+      <artifactId>spring-cloud-starter-bus-amqp</artifactId>
     </dependency>
-
   </dependencies>
 
   <build>


### PR DESCRIPTION
…eam-rabbit

Using a single spring bus technology for multiple messaging concerns.
Also using spring cloud release train label.