### PR TITLE
Feature/shared logback config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,15 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-bus-amqp</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+      <version>2.6.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.4.2.RELEASE</version>
+    <version>1.5.2.RELEASE</version>
   </parent>
 
   <properties>
@@ -20,6 +20,8 @@
     <unit-tests.skip>false</unit-tests.skip>
     <integration-tests.skip>true</integration-tests.skip>
     <docker.image.prefix>fwsbac</docker.image.prefix>
+    <janino.version>3.0.7</janino.version>
+    <logstash-appender.version>4.8</logstash-appender.version>
 
     <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
@@ -31,7 +33,7 @@
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
-        <version>Camden.SR6</version>
+        <version>Dalston.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -58,7 +60,12 @@
     <dependency>
       <groupId>org.codehaus.janino</groupId>
       <artifactId>janino</artifactId>
-      <version>2.6.1</version>
+      <version>${janino.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.logstash.logback</groupId>
+      <artifactId>logstash-logback-encoder</artifactId>
+      <version>${logstash-appender.version}</version>
     </dependency>
   </dependencies>
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,23 @@ management:
   health:
     rabbit:
       enabled: false
+---
+# Remote development profile
+spring:
+  profiles: remote-development
+
+logstash-destination: logstash.sbtds.org:4560
+
+---
+# QA profile
+spring:
+  profiles: qa
+
+logstash-destination: logstash.sbtds.org:4560
+
+---
+# AWS development kubernetes profile
+spring:
+  profiles: awsdev
+
+logstash-destination: logstash.sbtds.org:4560

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,23 +5,3 @@ management:
   health:
     rabbit:
       enabled: false
----
-# Remote development profile
-spring:
-  profiles: remote-development
-
-logstash-destination: logstash.sbtds.org:4560
-
----
-# QA profile
-spring:
-  profiles: qa
-
-logstash-destination: logstash.sbtds.org:4560
-
----
-# AWS development kubernetes profile
-spring:
-  profiles: awsdev
-
-logstash-destination: logstash.sbtds.org:4560

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Root logger is set to INFO and logs are sent to CONSOLE and logstash via tcp.
+
+Spring boot default log levels are used.
+-->
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <springProperty name="LOGSTASH_DESTINATION" source="logstash-destination"/>
+
+    <if condition='isDefined("LOGSTASH_DESTINATION")'>
+        <then>
+            <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+                <destination>${LOGSTASH_DESTINATION}</destination>
+                <!-- encoder is required -->
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+            </appender>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+
+        <if condition='isDefined("LOGSTASH_DESTINATION")'>
+            <then>
+                <appender-ref ref="LOGSTASH"/>
+            </then>
+        </if>
+    </root>
+</configuration>


### PR DESCRIPTION
Upgrade to spring cloud Dalston release and spring boot 1.5.2.

Enable centralized logging on the spring cloud config server application.

Configure location of logstash server as a spring profile aware property value for the various deployment environments (staging, kubernetes staging, qa).