### PR TITLE
Disable cloud bus for local development spring profile

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 spring:
   profiles: local-development
+  cloud.bus.enabled: false
 
 management:
   health:


### PR DESCRIPTION
Spring cloud bus requires a running rabbitmq.
Prevents warning log messages when rabbitmq is not running.